### PR TITLE
Reference correct cloudless repo in pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,2 +1,2 @@
 [packages]
-cloudless = {git = "https://github.com/sverch/cloudless", ref = "master", editable = true}
+cloudless = {git = "https://github.com/getcloudless/cloudless", ref = "master", editable = true}


### PR DESCRIPTION
Cloudless no longer lives at the repo there.