### PR TITLE
Allow vault ports in test fixture

### DIFF
--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -29,7 +29,7 @@ class BlueprintTest(BlueprintTestInterface):
         created.
         """
         my_ip = requests.get("http://ipinfo.io/ip")
-        test_machine = CidrBlock(my_ip.content.decode("utf-8"))
+        test_machine = CidrBlock(my_ip.content.decode("utf-8").strip())
         self.client.paths.add(test_machine, service, 8200)
         self.client.paths.add(test_machine, service, 8201)
 

--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -28,8 +28,10 @@ class BlueprintTest(BlueprintTestInterface):
         Do any setup that must happen after the service under test has been
         created.
         """
-        internet = CidrBlock("0.0.0.0/0")
-        self.client.paths.add(internet, service, 80)
+        my_ip = requests.get("http://ipinfo.io/ip")
+        test_machine = CidrBlock(my_ip.content.decode("utf-8"))
+        self.client.paths.add(test_machine, service, 8200)
+        self.client.paths.add(test_machine, service, 8201)
 
     def verify(self, network, service, setup_info):
         """


### PR DESCRIPTION
Also allow only the IP of the test machine for security in case someone quickly scans for this machine.